### PR TITLE
Fix TSHeightsParams.text flow definition

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -89,7 +89,7 @@ export type TSFontForStyle = {
 
 export type TSHeightsParams = TSFontSpecs & {
   /** The required text to measure. */
-  text: (string | null)[],
+  text: Array<string>,
   /** Maximum width of the area to display the text. @default MAX_INT */
   width?: number,
   /** @default true */


### PR DESCRIPTION
I got some flow errors when passing in an array of strings otherwise.