### PR TITLE
Introduce line end prop for Android to measure index of line end char

### DIFF
--- a/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeConf.java
+++ b/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeConf.java
@@ -94,6 +94,11 @@ final class RNTextSizeConf {
         return !mOpts.hasKey(name) || mOpts.getBoolean(name);
     }
 
+    Integer getIntOrNull(@NonNull final String name) {
+        return mOpts.hasKey(name)
+                ? mOpts.getInt(name) : null;
+    }
+
     @Nullable
     String getString(@NonNull final String name) {
         return mOpts.hasKey(name)

--- a/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
+++ b/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
@@ -161,6 +161,11 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
             result.putDouble("height", layout.getHeight() / density);
             result.putInt("lineCount", lineCount);
 
+            Integer lineEnd = conf.getIntOrNull("lineEnd");
+            if (lineEnd != null) {
+                result.putInt("lineEnd", layout.getLineVisibleEnd(lineEnd));
+            }
+
             promise.resolve(result);
         } catch (Exception e) {
             promise.reject(E_UNKNOWN_ERROR, e);
@@ -238,7 +243,7 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
                 result.pushDouble(layout.getHeight() / density);
             }
 
-        promise.resolve(result);
+            promise.resolve(result);
         } catch (Exception e) {
             promise.reject(E_UNKNOWN_ERROR, e);
         }

--- a/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
+++ b/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
@@ -161,9 +161,9 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
             result.putDouble("height", layout.getHeight() / density);
             result.putInt("lineCount", lineCount);
 
-            Integer lineEnd = conf.getIntOrNull("lineEnd");
-            if (lineEnd != null) {
-                result.putInt("lineEnd", layout.getLineVisibleEnd(lineEnd));
+            Integer lineEndForLineNo = conf.getIntOrNull("lineEndForLineNo");
+            if (lineEndForLineNo != null) {
+                result.putInt("lineEnd", layout.getLineVisibleEnd(lineEndForLineNo));
             }
 
             promise.resolve(result);

--- a/index.d.ts
+++ b/index.d.ts
@@ -106,6 +106,8 @@ declare module "react-native-text-size" {
     allowFontScaling?: boolean;
     /** Request an exact width calculation. For Android, iOS always do this. */
     usePreciseWidth?: boolean;
+    /** Request line end character index for the given line number - Android only **/
+    lineEnd?: number;
   }
 
   export type TSMeasureResult = {
@@ -113,6 +115,7 @@ declare module "react-native-text-size" {
     height: number,
     lastLineWidth?: number,
     lineCount: number,
+    lineEnd?: number,
   }
 
   interface TextSizeStatic {

--- a/index.d.ts
+++ b/index.d.ts
@@ -115,7 +115,7 @@ declare module "react-native-text-size" {
     height: number,
     lastLineWidth?: number,
     lineCount: number,
-    lineEnd?: number,
+    lineEndForLineNo?: number,
   }
 
   interface TextSizeStatic {

--- a/index.js.flow
+++ b/index.js.flow
@@ -105,6 +105,8 @@ export type TSMeasureParams = TSFontSpecs & {
   allowFontScaling?: boolean,
   /** Request an exact width calculation. For Android, iOS always do this. */
   usePreciseWidth?: boolean;
+  /** Request line end character index for the given line number - Android only **/
+  lineEnd?: number;
 }
 
 export interface TSMeasureResult {
@@ -112,6 +114,7 @@ export interface TSMeasureResult {
   height: number;
   lastLineWidth?: number;
   lineCount: number;
+  lineEnd?: number;
 }
 
 declare interface TextSizeStatic {

--- a/index.js.flow
+++ b/index.js.flow
@@ -114,7 +114,7 @@ export interface TSMeasureResult {
   height: number;
   lastLineWidth?: number;
   lineCount: number;
-  lineEnd?: number;
+  lineEndForLineNo?: number;
 }
 
 declare interface TextSizeStatic {


### PR DESCRIPTION
Great library, really saved our lives. Thanks!

We have a specific use case where we need to measure how many words can fit in a certain textbox within a max amount of lines. This is especially useful if you want to simulate inline images and text wraps, where you need to split the text into multiple textboxes around the image. 

This PR introduces a new prop to the measure method, called `lineEndForLineNo`, and returns the number of characters that can fit into those lines. This utilizes Android Layout's `getLineVisibleEnd` method.