### PR TITLE
fix podspec to allow RN0.60 autolinking on iOS

### DIFF
--- a/ios/RNTextSize.podspec
+++ b/ios/RNTextSize.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.author       = package['author']
   s.platform     = :ios, '9.0'
   s.source       = { :git => package['repository'], :tag => "v#{s.version}" }
-  s.source_files = 'RNTextSize/**/*.{h,m}'
+  s.source_files = '*.{h,m}'
   s.requires_arc = true
 
   s.dependency 'React'


### PR DESCRIPTION
Link to issue: https://github.com/aMarCruz/react-native-text-size/issues/16