### PR TITLE
Add numberOfLines, lineHeight options; create flatSizes; increase accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
-- Updated README.md with example for flatHeights - Thanks to @donni106
+- Update README.md with example for flatHeights - Thanks to @donni106
+- Create new flatSizes function that also gets the widths
+- Add support for `numberOfLines` and `maxWidth/maxHeight` dimensions.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ fontStyle          | string  | 'normal' | One of "normal" or "italic".
 lineHeight         | number  | (none)   | The line height of each line. Defaults to the font size.
 numberOfLines      | number  | (none)   | Limit the number of lines the text can render on
 fontVariant        | array   | (none)   | _iOS only_
+ceilToClosestPixel | boolean | true     | _iOS only_. If true, we ceil the output to the closest pixel. This is React Native's default behavior, but can be disabled if you're trying to measure text in a native component that doesn't respect this.
 allowFontScaling   | boolean | true     | To respect the user' setting of large fonts (i.e. use SP units).
 letterSpacing      | number  | (none)   | Additional spacing between characters (aka `tracking`).<br>**Note:** In iOS a zero cancels automatic kerning.<br>_All iOS, Android with API 21+_
 includeFontPadding | boolean | true     | Include additional top and bottom padding, to avoid clipping certain characters.<br>_Android only_

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See [Manual Installation][2] on the Wiki as an alternative if you have problems 
 
 - [`measure`](#measure)
 
-- [`flatHeights`](#flatheights)
+- [`flatHeights` and `flatSizes`](#flatheights)
 
 - [`specsForTextStyles`](#specsfortextstyles)
 
@@ -199,9 +199,10 @@ class Test extends Component<Props, State> {
 
 ```ts
 flatHeights(options: TSHeightsParams): Promise<number[]>
+flatSizes(options: TSHeightsParams): Promise<TSFlatSizes>
 ```
 
-Calculate the height of each of the strings in an array.
+Calculate the height (or sizes) of each of the strings in an array.
 
 This is an alternative to `measure` designed for cases in which you have to calculate the height of numerous text blocks with common characteristics (width, font, etc), a typical use case with `<FlatList>` or `<RecyclerListView>` components.
 
@@ -213,6 +214,8 @@ I did tests on 5,000 random text blocks and these were the results (ms):
 ------- | --------: | ----------:
 Android | 49,624    | 1,091
 iOS     |  1,949    |   732
+
+Note that `flatSizes` is somewhat slower than `flatHeights` on Android since it needs to iterate through lines to find the maximum line length.
 
 In the future I will prepare an example of its use with FlatList and multiple styles on the same card.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ In both functions, the text to be measured is required, but the rest of the para
 - `textBreakStrategy` (Android)
 - `letterSpacing`
 - `allowFontScaling`
+- `numberOfLines`
 - `width`: Constraint for automatic line-break based on text-break strategy.
 
 In addition, the library includes functions to obtain information about the fonts visible to the App.
@@ -100,6 +101,7 @@ allowFontScaling   | boolean | true     | To respect the user' setting of large 
 letterSpacing      | number  | (none)   | Additional spacing between characters (aka `tracking`).<br>**Note:** In iOS a zero cancels automatic kerning.<br>_All iOS, Android with API 21+_
 includeFontPadding | boolean | true     | Include additional top and bottom padding, to avoid clipping certain characters.<br>_Android only_
 textBreakStrategy  | string  | 'highQuality' | One of 'simple', 'balanced', or 'highQuality'.<br>_Android only, with API 23+_
+numberOfLines      | number  | (none)   | Limit the number of lines the text can render on
 width              | number  | MAX_INT  | Restrict the width. The resulting height will vary depending on the automatic flow of the text.
 usePreciseWidth    | boolean | false    | If `true`, the result will include an exact `width` and the `lastLineWidth` property.<br>You can see the effect of this flag in the [sample App][sample-app].
 lineInfoForLine    | number  | (none)   | If `>=0`, the result will include a [lineInfo](#lineinfo) property with information for the required line number.
@@ -228,6 +230,7 @@ allowFontScaling    | boolean  | true
 letterSpacing       | number   | (none)
 includeFontPadding  | boolean  | true
 textBreakStrategy   | string   | 'highQuality'
+numberOfLines       | number   | (none)
 
 The result is a Promise that resolves to an array with the height of each block (in _SP_), in the same order in which the blocks were received.
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ In both functions, the text to be measured is required, but the rest of the para
 - `fontSize`
 - `fontWeight`
 - `fontStyle`
+- `lineHeight`
+- `numberOfLines`
 - `fontVariant` (iOS)
 - `includeFontPadding` (Android)
 - `textBreakStrategy` (Android)
 - `letterSpacing`
 - `allowFontScaling`
-- `numberOfLines`
 - `width`: Constraint for automatic line-break based on text-break strategy.
 
 In addition, the library includes functions to obtain information about the fonts visible to the App.
@@ -96,12 +97,13 @@ fontFamily         | string  | OS dependent | The default is the same applied by
 fontWeight         | string  | 'normal' | On android, numeric ranges has no granularity and '500' to '900' becomes 'bold', but you can use a `fontFamily` of specific weight ("sans-serif-thin", "sans-serif-medium", etc).
 fontSize           | number  | 14       | The default font size comes from RN.
 fontStyle          | string  | 'normal' | One of "normal" or "italic".
+lineHeight         | number  | (none)   | The line height of each line. Defaults to the font size.
+numberOfLines      | number  | (none)   | Limit the number of lines the text can render on
 fontVariant        | array   | (none)   | _iOS only_
 allowFontScaling   | boolean | true     | To respect the user' setting of large fonts (i.e. use SP units).
 letterSpacing      | number  | (none)   | Additional spacing between characters (aka `tracking`).<br>**Note:** In iOS a zero cancels automatic kerning.<br>_All iOS, Android with API 21+_
 includeFontPadding | boolean | true     | Include additional top and bottom padding, to avoid clipping certain characters.<br>_Android only_
 textBreakStrategy  | string  | 'highQuality' | One of 'simple', 'balanced', or 'highQuality'.<br>_Android only, with API 23+_
-numberOfLines      | number  | (none)   | Limit the number of lines the text can render on
 width              | number  | MAX_INT  | Restrict the width. The resulting height will vary depending on the automatic flow of the text.
 usePreciseWidth    | boolean | false    | If `true`, the result will include an exact `width` and the `lastLineWidth` property.<br>You can see the effect of this flag in the [sample App][sample-app].
 lineInfoForLine    | number  | (none)   | If `>=0`, the result will include a [lineInfo](#lineinfo) property with information for the required line number.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,21 +13,20 @@ def _compileSdkVersion  = safeExtGet('compileSdkVersion', 28)
 def _targetSdkVersion   = safeExtGet('targetSdkVersion', 28)
 def _minSdkVersion      = safeExtGet('minSdkVersion', 16)
 
-buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
-    }
-}
-
+// Based on https://github.com/aMarCruz/react-native-text-size/pull/41
+// Removed dead buildscript block that called jcenter().
 apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion _compileSdkVersion
     buildToolsVersion _buildToolsVersion
+
+    // Based on https://github.com/thebylito/react-native-navigation-bar-color/pull/72
+    // AGP 8 requires an explicit namespace instead of the manifest package attribute.
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+    if (agpVersion >= 7) {
+        namespace 'com.github.amarcruz.rntextsize'
+    }
 
     defaultConfig {
         minSdkVersion _minSdkVersion
@@ -43,7 +42,7 @@ android {
 repositories {
     mavenLocal()
     google()
-    jcenter()
+    mavenCentral()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
         url "$rootDir/../node_modules/react-native/android"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.github.amarcruz.rntextsize">
+<!-- Based on https://github.com/thebylito/react-native-navigation-bar-color/pull/72 -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeConf.java
+++ b/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeConf.java
@@ -67,6 +67,7 @@ final class RNTextSizeConf {
     final String fontFamily;
     final float fontSize;
     final int fontStyle;
+    final float lineHeight;
     final boolean includeFontPadding;
     final float letterSpacing;
     final @Nullable Integer numberOfLines;
@@ -85,6 +86,7 @@ final class RNTextSizeConf {
         fontFamily = getString("fontFamily");
         fontSize = getFontSizeOrDefault();
         fontStyle = getFontStyle();
+        lineHeight = getFloatOrNaN("lineHeight");
         includeFontPadding = forText && getBooleanOrTrue("includeFontPadding");
 
         // letterSpacing is supported in RN 0.55+

--- a/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeConf.java
+++ b/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeConf.java
@@ -69,6 +69,7 @@ final class RNTextSizeConf {
     final int fontStyle;
     final boolean includeFontPadding;
     final float letterSpacing;
+    final @Nullable Integer numberOfLines;
 
     /**
      * Proccess the user specs. Set both `allowFontScaling` & `includeFontPadding` to the user
@@ -88,6 +89,10 @@ final class RNTextSizeConf {
 
         // letterSpacing is supported in RN 0.55+
         letterSpacing = supportLetterSpacing() ? getFloatOrNaN("letterSpacing") : Float.NaN;
+
+        Integer rawNumberOfLines = getIntOrNull("numberOfLines");
+        if (rawNumberOfLines != null && rawNumberOfLines < 0) rawNumberOfLines = null;
+        numberOfLines = rawNumberOfLines;
     }
 
     boolean has(@Nonnull final String name) {

--- a/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
+++ b/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
@@ -10,6 +10,7 @@ import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 import android.text.StaticLayout;
 import android.text.TextPaint;
+import android.text.TextUtils;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
@@ -118,13 +119,17 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
 
             if (layout == null) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    layout = StaticLayout.Builder.obtain(text, 0, text.length(), textPaint, hintWidth)
+                    StaticLayout.Builder builder = StaticLayout.Builder.obtain(text, 0, text.length(), textPaint, hintWidth)
                             .setAlignment(Layout.Alignment.ALIGN_NORMAL)
                             .setBreakStrategy(conf.getTextBreakStrategy())
                             .setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NORMAL)
                             .setIncludePad(includeFontPadding)
-                            .setLineSpacing(SPACING_ADDITION, SPACING_MULTIPLIER)
-                            .build();
+                            .setLineSpacing(SPACING_ADDITION, SPACING_MULTIPLIER);
+                    if (conf.numberOfLines != null) {
+                        builder = builder.setMaxLines(conf.numberOfLines)
+                                .setEllipsize(TextUtils.TruncateAt.END);
+                    }
+                    layout = builder.build();
                 } else {
                     layout = new StaticLayout(
                             text,
@@ -228,13 +233,17 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
                 sb.replace(0, sb.length(), text);
 
                 if (Build.VERSION.SDK_INT >= 23) {
-                    layout = StaticLayout.Builder.obtain(sb, 0, sb.length(), textPaint, (int) width)
+                    StaticLayout.Builder builder = StaticLayout.Builder.obtain(sb, 0, sb.length(), textPaint, (int) width)
                             .setAlignment(Layout.Alignment.ALIGN_NORMAL)
                             .setBreakStrategy(textBreakStrategy)
                             .setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NORMAL)
                             .setIncludePad(includeFontPadding)
-                            .setLineSpacing(SPACING_ADDITION, SPACING_MULTIPLIER)
-                            .build();
+                            .setLineSpacing(SPACING_ADDITION, SPACING_MULTIPLIER);
+                    if (conf.numberOfLines != null) {
+                        builder = builder.setMaxLines(conf.numberOfLines)
+                                .setEllipsize(TextUtils.TruncateAt.END);
+                    }
+                    layout = builder.build();
                 } else {
                     layout = new StaticLayout(
                             sb,

--- a/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
+++ b/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
@@ -6,7 +6,6 @@ import android.graphics.Typeface;
 import android.os.Build;
 import android.text.BoringLayout;
 import android.text.Layout;
-import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 import android.text.StaticLayout;
 import android.text.TextPaint;
@@ -171,7 +170,7 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
     @SuppressWarnings("unused")
     @ReactMethod
     public void flatSizes(@Nullable final ReadableMap specs, final Promise promise) {
-        flatHeightsInner(specs, promise, true);
+        flatHeightsInner(specs, promise, FlatHeightsMode.sizes);
     }
 
     /**
@@ -182,7 +181,7 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
     @SuppressWarnings("unused")
     @ReactMethod
     public void flatHeights(@Nullable final ReadableMap specs, final Promise promise) {
-        flatHeightsInner(specs, promise, false);
+        flatHeightsInner(specs, promise, FlatHeightsMode.heights);
     }
 
     /**
@@ -278,7 +277,12 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
     //
     // ============================================================================
 
-    private void flatHeightsInner(@Nullable final ReadableMap specs, final Promise promise, boolean includeWidths) {
+    private enum FlatHeightsMode {
+        heights,
+        sizes,
+    }
+
+    private void flatHeightsInner(@Nullable final ReadableMap specs, final Promise promise, FlatHeightsMode mode) {
         final RNTextSizeConf conf = getConf(specs, promise, true);
         if (conf == null) {
             return;
@@ -293,7 +297,6 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
         final float density = getCurrentDensity();
         final float width = conf.getWidth(density);
         final boolean includeFontPadding = conf.includeFontPadding;
-        final int textBreakStrategy = conf.getTextBreakStrategy();
 
         final WritableArray heights = Arguments.createArray();
         final WritableArray widths = Arguments.createArray();
@@ -324,25 +327,66 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
                 // Reset the SB text, the attrs will expand to its full length
                 sb.replace(0, sb.length(), text);
                 layout = buildStaticLayout(conf, includeFontPadding, sb, textPaint, (int) width);
-                heights.pushDouble(layout.getHeight() / density);
 
-                if (includeWidths) {
+                float height = layout.getHeight() / density;
+
+                if (conf.numberOfLines != null || mode == FlatHeightsMode.sizes) {
                     final int lineCount = layout.getLineCount();
-                    float measuredWidth = 0;
-                    for (int i = 0; i < lineCount; i++) {
-                        measuredWidth = Math.max(measuredWidth, layout.getLineMax(i));
+
+                    if (conf.numberOfLines != null) {
+                        boolean lastLineHasEllipsis = layout.getEllipsisCount(lineCount - 1) > 0;
+                        // For unknown reasons, the text will be 2 subpixels shorter if truncated
+                        // due to numberOfLines. See the lines mentioning `numberOfLines` in the
+                        // TextHeights stories: this logic was created for those cases.
+                        if (lastLineHasEllipsis) {
+                            height -= 2 / density;
+                        }
                     }
-                    widths.pushDouble(measuredWidth / density);
+
+                    if (mode == FlatHeightsMode.sizes) {
+                        float measuredWidth = 0;
+                        for (int i = 0; i < lineCount; i++) {
+                            measuredWidth = Math.max(measuredWidth, layout.getLineMax(i));
+                        }
+                        widths.pushDouble(measuredWidth / density);
+                    }
                 }
+
+                heights.pushDouble(height);
             }
 
-            if (includeWidths) {
-                final WritableMap output = Arguments.createMap();
-                output.putArray("widths", widths);
-                output.putArray("heights", heights);
-                promise.resolve(output);
-            } else {
-                promise.resolve(heights);
+            switch (mode) {
+                case sizes: {
+                    final WritableMap output = Arguments.createMap();
+                    // We output an object with 3 arrays instead of an array of
+                    // objects because it's much faster.
+                    //
+                    // Changing this output to arrays of objects quadrupled the
+                    // running time of flatSizes: 1000 iterations of the
+                    // following code went from 13ms to 47ms each.
+                    //
+                    // ```ts
+                    // const heightsParams: TSHeightsParams = {
+                    //   text: _.times(
+                    //     20,
+                    //     () =>
+                    //       'This is some text that is quite long. It should wrap onto a few lines',
+                    //   ),
+                    //   ...defaultTextStyle,
+                    //   width: 150,
+                    // };
+                    //
+                    // await TextSize.flatSizes(heightsParams);
+                    // ```
+                    output.putArray("widths", widths);
+                    output.putArray("heights", heights);
+                    promise.resolve(output);
+                    break;
+                }
+                case heights: {
+                    promise.resolve(heights);
+                    break;
+                }
             }
         } catch (Exception e) {
             promise.reject(E_UNKNOWN_ERROR, e);

--- a/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeSpannedText.java
+++ b/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeSpannedText.java
@@ -9,6 +9,8 @@ import android.text.style.AbsoluteSizeSpan;
 import android.text.style.MetricAffectingSpan;
 
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.views.text.CustomLineHeightSpan;
+import com.facebook.react.views.text.TextAttributes;
 
 import javax.annotation.Nonnull;
 
@@ -47,6 +49,13 @@ final class RNTextSizeSpannedText {
             priority++;
             setSpanOperation(text, end, priority,
                     new CustomStyleSpan(RNTextSizeConf.getFont(context, conf.fontFamily, conf.fontStyle)));
+        }
+
+        if (!Float.isNaN(conf.lineHeight)) {
+            priority++;
+            final TextAttributes textAttributes = new TextAttributes();
+            textAttributes.setLineHeight(conf.lineHeight);
+            setSpanOperation(text, end, priority, new CustomLineHeightSpan(textAttributes.getEffectiveLineHeight()));
         }
 
         return text;

--- a/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeSpannedText.java
+++ b/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeSpannedText.java
@@ -9,7 +9,10 @@ import android.text.style.AbsoluteSizeSpan;
 import android.text.style.MetricAffectingSpan;
 
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.views.text.CustomLineHeightSpan;
+// Changed from import com.facebook.react.views.text.CustomLineHeightSpan
+// since React Native moved the package in 0.81.5 to make it internal. We then
+// patched react-native to expose it again in the new path.
+import com.facebook.react.views.text.internal.span.CustomLineHeightSpan;
 import com.facebook.react.views.text.TextAttributes;
 
 import javax.annotation.Nonnull;

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,6 +70,14 @@ declare module "react-native-text-size" {
      * prop on `<Text>`
      */
     numberOfLines?: number;
+    /**
+     * @platform ios
+     *
+     * If true, we ceil the output to the closest pixel. This is React Native's
+     * default behavior, but can be disabled if you're trying to measure text in
+     * a native component that doesn't respect this.
+     */
+    ceilToClosestPixel?: boolean;
     /** @platform ios */
     fontVariant?: Array<TSFontVariant>;
     /** iOS all, Android SDK 21+ with RN 0.55+ */

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,6 +72,8 @@ declare module "react-native-text-size" {
     includeFontPadding?: boolean;
     /** @platform android (SDK 23+) */
     textBreakStrategy?: TSTextBreakStrategy;
+    /** Number of lines to limit the text to */
+    numberOfLines?: number;
   }
 
   export type TSFontForStyle = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,6 +64,12 @@ declare module "react-native-text-size" {
     fontSize?: number;
     fontStyle?: TSFontStyle;
     fontWeight?: TSFontWeight;
+    lineHeight?: number;
+    /**
+     * Number of lines to limit the text to. Corresponds to the `numberOfLines`
+     * prop on `<Text>`
+     */
+    numberOfLines?: number;
     /** @platform ios */
     fontVariant?: Array<TSFontVariant>;
     /** iOS all, Android SDK 21+ with RN 0.55+ */
@@ -72,8 +78,6 @@ declare module "react-native-text-size" {
     includeFontPadding?: boolean;
     /** @platform android (SDK 23+) */
     textBreakStrategy?: TSTextBreakStrategy;
-    /** Number of lines to limit the text to */
-    numberOfLines?: number;
   }
 
   export type TSFontForStyle = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare module "react-native-text-size" {
   export type TSFontVariant = 'small-caps' | 'oldstyle-nums' | 'lining-nums' | 'tabular-nums' | 'proportional-nums'
   export type TSTextBreakStrategy = 'simple' | 'highQuality' | 'balanced'
 
-  export type TSFontSize = {
+  export interface TSFontSize {
     readonly default: number,
     readonly button: number,
     readonly label: number,
@@ -41,7 +41,7 @@ declare module "react-native-text-size" {
   | 'title2'
   | 'title3'
 
-  export type TSFontInfo = {
+  export interface TSFontInfo {
     fontFamily: string | null,
     fontName?: string | null,
     fontWeight: TSFontWeight,
@@ -88,7 +88,7 @@ declare module "react-native-text-size" {
     textBreakStrategy?: TSTextBreakStrategy;
   }
 
-  export type TSFontForStyle = {
+  export interface TSFontForStyle {
     fontFamily: string,
     /** Unscaled font size, untits are SP in Android, points in iOS */
     fontSize: number,
@@ -143,7 +143,7 @@ declare module "react-native-text-size" {
     lineInfoForLine?: number;
   }
 
-  export type TSMeasureResult = {
+  export interface TSMeasureResult {
     /**
      * Total used width. It may be less or equal to the `width` option.
      *
@@ -185,8 +185,14 @@ declare module "react-native-text-size" {
     };
   }
 
+  export interface TSFlatSizes {
+    widths: number[];
+    heights: number[];
+  }
+
   interface TextSizeStatic {
     measure(params: TSMeasureParams): Promise<TSMeasureResult>;
+    flatSizes(params: TSHeightsParams): Promise<TSFlatSizes>;
     flatHeights(params: TSHeightsParams): Promise<number[]>;
     specsForTextStyles(): Promise<{ [key: string]: TSFontForStyle }>;
     fontFromSpecs(specs?: TSFontSpecs): Promise<TSFontInfo>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -192,8 +192,29 @@ declare module "react-native-text-size" {
 
   interface TextSizeStatic {
     measure(params: TSMeasureParams): Promise<TSMeasureResult>;
+
+    /**
+     * On Android, we benchmarked this to take 1.55x the time of flatHeights.
+     * Measuring the sizes for the following input 1000 times took 13.38ms vs.
+     * 8.6ms.
+     * 
+     * On iOS, this should run at roughly the same speed as flatHeights.
+     * 
+     * ```
+     * {
+     *   text: _.times(
+     *     20,
+     *     () =>
+     *       'This is some text that is quite long. It should wrap onto a few lines',
+     *   ),
+     *   ...defaultTextStyle,
+     *   width: 150,
+     * };
+     * ```
+     */
     flatSizes(params: TSHeightsParams): Promise<TSFlatSizes>;
     flatHeights(params: TSHeightsParams): Promise<number[]>;
+
     specsForTextStyles(): Promise<{ [key: string]: TSFontForStyle }>;
     fontFromSpecs(specs?: TSFontSpecs): Promise<TSFontInfo>;
     fontFamilyNames(): Promise<string[]>;

--- a/index.js.flow
+++ b/index.js.flow
@@ -70,6 +70,14 @@ export type TSFontSpecs = {
    * prop on `<Text>`
    */
   numberOfLines?: number,
+  /**
+   * @platform ios
+   *
+   * If true, we ceil the output to the closest pixel. This is React Native's
+   * default behavior, but can be disabled if you're trying to measure text in
+   * a native component that doesn't respect this.
+   */
+  ceilToClosestPixel?: boolean;
   /** @platform ios */
   fontVariant?: Array<TSFontVariant>,
   /** iOS all, Android SDK 21+ with RN 0.55+ */

--- a/index.js.flow
+++ b/index.js.flow
@@ -72,6 +72,8 @@ export type TSFontSpecs = {
   includeFontPadding?: boolean,
   /** @platform android (SDK 23+) */
   textBreakStrategy?: TSTextBreakStrategy,
+  /** Number of lines to limit the text to */
+  numberOfLines?: number,
 }
 
 export type TSFontForStyle = {

--- a/index.js.flow
+++ b/index.js.flow
@@ -64,6 +64,12 @@ export type TSFontSpecs = {
   fontSize?: number,
   fontStyle?: TSFontStyle,
   fontWeight?: TSFontWeight,
+  lineHeight?: number;
+  /**
+   * Number of lines to limit the text to. Corresponds to the `numberOfLines`
+   * prop on `<Text>`
+   */
+  numberOfLines?: number,
   /** @platform ios */
   fontVariant?: Array<TSFontVariant>,
   /** iOS all, Android SDK 21+ with RN 0.55+ */
@@ -72,8 +78,6 @@ export type TSFontSpecs = {
   includeFontPadding?: boolean,
   /** @platform android (SDK 23+) */
   textBreakStrategy?: TSTextBreakStrategy,
-  /** Number of lines to limit the text to */
-  numberOfLines?: number,
 }
 
 export type TSFontForStyle = {

--- a/index.js.flow
+++ b/index.js.flow
@@ -184,8 +184,14 @@ export interface TSMeasureResult {
   }
 }
 
+export interface TSFlatSizes {
+  widths: number[];
+  heights: number[];
+}
+
 declare interface TextSizeStatic {
   measure(params: TSMeasureParams): Promise<TSMeasureResult>;
+  flatSizes(params: TSHeightsParams): Promise<TSFlatSizes>;
   flatHeights(params: TSHeightsParams): Promise<number[]>;
   specsForTextStyles(): Promise<{ [string]: TSFontForStyle }>;
   fontFromSpecs(specs: TSFontSpecs): Promise<TSFontInfo>;

--- a/ios/RNTextSize.m
+++ b/ios/RNTextSize.m
@@ -361,19 +361,20 @@ RCT_EXPORT_METHOD(fontNamesForFamilyName:(NSString * _Nullable)fontFamily
   NSMutableArray<NSNumber *> *widths = [[NSMutableArray alloc] initWithCapacity:texts.count];
   NSMutableArray<NSNumber *> *heights = [[NSMutableArray alloc] initWithCapacity:texts.count];
 
-
   for (int ix = 0; ix < texts.count; ix++) {
     NSString *text = texts[ix];
 
     // If this element is `null` or another type, return zero
     if (![text isKindOfClass:[NSString class]]) {
       heights[ix] = @0;
+      widths[ix] = @0;
       continue;
     }
 
     // If empty, return the minimum height of <Text> components
     if (!text.length) {
       heights[ix] = @14;
+      widths[ix] = @0;
       continue;
     }
 

--- a/ios/RNTextSize.m
+++ b/ios/RNTextSize.m
@@ -6,8 +6,8 @@
 #import <React/RCTUtils.h>
 #else
 #import "React/RCTConvert.h"   // Required when used as a Pod in a Swift project
-#import "React/RCTFont.h"
-#import "React/RCTUtils.h"
+#import <React/RCTFont.h>
+#import <React/RCTUtils.h>
 #endif
 
 #import <CoreText/CoreText.h>
@@ -99,7 +99,12 @@ RCT_EXPORT_METHOD(measure:(NSDictionary * _Nullable)options
 
   NSTextContainer *textContainer = [[NSTextContainer alloc] initWithSize:maxSize];
   textContainer.lineFragmentPadding = 0.0;
-  textContainer.lineBreakMode = NSLineBreakByClipping; // no maxlines support
+  textContainer.lineBreakMode = NSLineBreakByClipping;
+
+  const NSInteger numberOfLines = [RCTConvert NSInteger:options[@"numberOfLines"]];
+  if (numberOfLines > 0) {
+    textContainer.maximumNumberOfLines = numberOfLines;
+  }
 
   NSLayoutManager *layoutManager = [NSLayoutManager new];
   [layoutManager addTextContainer:textContainer];
@@ -178,7 +183,12 @@ RCT_EXPORT_METHOD(flatHeights:(NSDictionary * _Nullable)options
 
   NSTextContainer *textContainer = [[NSTextContainer alloc] initWithSize:maxSize];
   textContainer.lineFragmentPadding = 0.0;
-  textContainer.lineBreakMode = NSLineBreakByClipping; // no maxlines support
+  textContainer.lineBreakMode = NSLineBreakByClipping;
+
+  const NSInteger numberOfLines = [RCTConvert NSInteger:options[@"numberOfLines"]];
+  if (numberOfLines > 0) {
+    textContainer.maximumNumberOfLines = numberOfLines;
+  }
 
   NSLayoutManager *layoutManager = [NSLayoutManager new];
   [layoutManager addTextContainer:textContainer];

--- a/ios/RNTextSize.m
+++ b/ios/RNTextSize.m
@@ -178,7 +178,9 @@ RCT_EXPORT_METHOD(flatHeights:(NSDictionary * _Nullable)options
   [textStorage addLayoutManager:layoutManager];
 
   NSMutableArray<NSNumber *> *result = [[NSMutableArray alloc] initWithCapacity:texts.count];
-  const CGFloat epsilon = 0.001;
+
+  const CGFloat scaleMultiplier = _bridge ? _bridge.accessibilityManager.multiplier : 1.0;
+  const CGFloat epsilon = scaleMultiplier != 1.0 ? 0.001 : 0;
 
   for (int ix = 0; ix < texts.count; ix++) {
     NSString *text = texts[ix];

--- a/ios/RNTextSize.m
+++ b/ios/RNTextSize.m
@@ -573,7 +573,7 @@ RCT_EXPORT_METHOD(fontNamesForFamilyName:(NSString * _Nullable)fontFamily
   return count ? [NSArray arrayWithObjects:outArr count:count] : nil;
 }
 
-- (CGSize)maxSizeFromOptions:(NSDictionary * _Nullable)options
+- (CGSize)maxSizeFromOptions:(const NSDictionary *)options
 {
   const CGFloat optWidth = CGFloatValueFrom(options[@"width"]);
   const CGFloat maxWidth = isnan(optWidth) || isinf(optWidth) ? CGFLOAT_MAX : optWidth;
@@ -584,7 +584,7 @@ RCT_EXPORT_METHOD(fontNamesForFamilyName:(NSString * _Nullable)fontFamily
 /**
  * Creates a textContainer with the width and numberOfLines from options.
  */
-- (NSTextContainer *)textContainerFromOptions:(NSDictionary * _Nullable)options
+- (NSTextContainer *)textContainerFromOptions:(const NSDictionary *)options
                                   withMaxSize:(CGSize)maxSize
 {
   NSTextContainer *textContainer = [[NSTextContainer alloc] initWithSize:maxSize];
@@ -603,7 +603,7 @@ RCT_EXPORT_METHOD(fontNamesForFamilyName:(NSString * _Nullable)fontFamily
  * Creates attributes that should be passed into the TextStorage based on
  * parameters and the options the user passes in.
  */
-- (NSDictionary<NSAttributedStringKey,id> *const)textStorageAttributesFromOptions:(NSDictionary * _Nullable)options
+- (NSDictionary<NSAttributedStringKey,id> *const)textStorageAttributesFromOptions:(const NSDictionary *)options
                                                                          withFont:(UIFont *const _Nullable)font
                                                                 withLetterSpacing:(CGFloat)letterSpacing
 {
@@ -634,9 +634,9 @@ RCT_EXPORT_METHOD(fontNamesForFamilyName:(NSString * _Nullable)fontFamily
  * React Native ceils sizes to the nearest pixels by default, so we usually
  * want to adjust it to that
  */
-- (CGFloat)adjustMeasuredSize:(const CGFloat)size
-                  withOptions:(NSDictionary *)options
-                  withMaxSize:(const CGFloat)maxSize
+- (CGFloat)adjustMeasuredSize:(CGFloat)size
+                  withOptions:(const NSDictionary *)options
+                  withMaxSize:(CGFloat)maxSize
 {
   CGFloat adjusted = size;
 

--- a/ios/RNTextSize.m
+++ b/ios/RNTextSize.m
@@ -651,7 +651,7 @@ RCT_EXPORT_METHOD(fontNamesForFamilyName:(NSString * _Nullable)fontFamily
   }
   adjusted = MIN(adjusted, maxSize);
 
-  return size;
+  return adjusted;
 }
 
 @end

--- a/ios/RNTextSize.m
+++ b/ios/RNTextSize.m
@@ -616,8 +616,9 @@ RCT_EXPORT_METHOD(fontNamesForFamilyName:(NSString * _Nullable)fontFamily
   const CGFloat lineHeight = CGFloatValueFrom(options[@"lineHeight"]);
   if (!isnan(lineHeight)) {
     NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
-    [style setMinimumLineHeight:lineHeight];
-    [style setMaximumLineHeight:lineHeight];
+    const CGFloat scaleMultiplier = _bridge ? _bridge.accessibilityManager.multiplier : 1.0;
+    [style setMinimumLineHeight:lineHeight * scaleMultiplier];
+    [style setMaximumLineHeight:lineHeight * scaleMultiplier];
     [attributes setObject:style forKey:NSParagraphStyleAttributeName];
   }
 


### PR DESCRIPTION
## Motivation

We have some Text components that

- Use the `numberOfLines` prop to limit lines
- Use the `lineHeight` style to change from the default line height
- Have variable width

We want to measure their height using `flatHeights`.

This also increases accuracy for both iOS and Android by fixing tiny discrepancies.

## Fix

- Add handling for both Android and iOS for new FontSpecs called `numberOfLines` and `flatHeights`. This matches the `<Text numberOfLines={...}>` prop
- Add new `flatSizes` function that behaves the same as `flatHeights`, but returns both the width and height. We use arrays (instead of objects with width and height) to reduce the amount key data passed over the React Native bridge

## Testing

Created Storybook story in our app to test it on both Android and iOS:

| iOS | Android |
| --- | --- |
![image](https://user-images.githubusercontent.com/2937410/160946846-d081895b-b221-4f0d-8ea9-78ab0e991cf6.png) | ![image](https://user-images.githubusercontent.com/2937410/160947683-a78222ad-276f-46a5-9c54-a8b8358f8191.png) |