### PR TITLE
Fix Autolinking for React Native 0.69

### DIFF
--- a/RNTextSize.podspec
+++ b/RNTextSize.podspec
@@ -1,5 +1,5 @@
 require 'json'
-package = JSON.parse(File.read('../package.json'))
+package = JSON.parse(File.read('./package.json'))
 
 Pod::Spec.new do |s|
   s.name         = 'RNTextSize'
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.author       = package['author']
   s.platform     = :ios, '9.0'
   s.source       = { :git => package['repository'], :tag => "v#{s.version}" }
-  s.source_files = '*.{h,m}'
+  s.source_files = 'ios/*.{h,m}'
   s.requires_arc = true
 
   s.dependency 'React'


### PR DESCRIPTION
Fixes #38 

Moved podspec file to root directory, as the podspec file needs to be in root directory in order for autolinking to work in react-native/cli v8